### PR TITLE
Refactor duplicate cost and achievement logic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { AchievementToasts } from "./components/AchievementToasts";
 import { AchievementGallery } from "./components/AchievementGallery";
 import type { UpgradeDef } from "./types";
 import type { ArtifactDef } from "./prestige";
-import { artifactCost, costOf, isUpgradeAtMaxLevel } from "./logic";
+import { costOf, isUpgradeAtMaxLevel } from "./logic";
 import { ScrollArea } from "./components/ui/scroll-area";
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "./components/ui/accordion";
 import { TooltipProvider } from "./components/ui/tooltip";
@@ -53,7 +53,7 @@ export default function App() {
   const handleArtifactPurchase = useCallback((def: ArtifactDef) => {
     setGame(prev => {
       const level = prev.artifacts?.[def.id] || 0;
-      const price = artifactCost(def, level);
+      const price = costOf(def, level);
       if (prev.prestigeGems < price) return prev;
       return {
         ...prev,

--- a/src/components/PrestigePanel.tsx
+++ b/src/components/PrestigePanel.tsx
@@ -10,7 +10,7 @@ import {
   Gem
 } from "lucide-react";
 import type { GameSnapshot } from "../types";
-import { artifactCost, calculatePrestigeGems, getGemMultiplier } from "../logic";
+import { costOf, calculatePrestigeGems, getGemMultiplier } from "../logic";
 import { fmt, cn } from "../utils";
 import { ARTIFACT_DEFS } from "../prestige";
 import type { ArtifactDef } from "../prestige";
@@ -76,7 +76,7 @@ export function PrestigePanel({ game, derived, onPrestige, onBuyArtifact }: Pres
           <TabsContent value="artifacts" className="flex-1 overflow-y-auto pr-1 -mr-1 custom-scrollbar space-y-3">
              {ARTIFACT_DEFS.map(def => {
                 const level = game.artifacts?.[def.id] || 0;
-                const cost = artifactCost(def, level);
+                const cost = costOf(def, level);
                 const canAfford = game.prestigeGems >= cost;
                 const progress = game.prestigeGems / cost;
 

--- a/src/hooks/useGameController.ts
+++ b/src/hooks/useGameController.ts
@@ -106,6 +106,33 @@ export function useGameController() {
   const [game, setGame] = useState<GameSnapshot>(hydrateSavedState);
   const derived = useMemo(() => deriveStats(game), [game]);
 
+
+  const processAchievements = useCallback((state: GameSnapshot, shouldExplode: boolean) => {
+    const unlocked = checkAchievements(state);
+    if (unlocked.length > 0) {
+      applyAchievementRewards(state, unlocked);
+      state.achievements = [...(state.achievements || []), ...unlocked];
+      const newNotifs = unlocked.map(id => {
+        const def = ACHIEVEMENT_DEFS.find(d => d.id === id);
+        return { id, name: def?.name || "Unknown" };
+      });
+      setAchievementNotifs(curr => [...curr, ...newNotifs]);
+      setTimeout(() => {
+        setAchievementNotifs(curr => curr.filter(n => !newNotifs.includes(n)));
+      }, 4000);
+      if (shouldExplode) {
+        try {
+          if (pixiRef.current && clickZoneRef.current) {
+            const clickRect = clickZoneRef.current.getBoundingClientRect();
+            const cx = clickRect.left + clickRect.width * 0.5;
+            const cy = clickRect.top + clickRect.height * 0.5;
+            pixiRef.current.spawnExplosion(cx, cy);
+          }
+        } catch (e) { }
+      }
+    }
+  }, []);
+
   const handleActivateSkill = useCallback((skillId: string) => {
     setGame(prev => {
       const next = activateSkill(prev, skillId);
@@ -368,25 +395,7 @@ export function useGameController() {
         prestigeGems: (prev.prestigeGems || 0) + gemsFound
       };
 
-      const unlocked = checkAchievements(nextState);
-      if (unlocked.length > 0) {
-        applyAchievementRewards(nextState, unlocked);
-        nextState.achievements = [...(nextState.achievements || []), ...unlocked];
-        const newNotifs = unlocked.map(id => {
-          const def = ACHIEVEMENT_DEFS.find(d => d.id === id);
-          return { id, name: def?.name || "Unknown" };
-        });
-        setAchievementNotifs(curr => [...curr, ...newNotifs]);
-        setTimeout(() => {
-          setAchievementNotifs(curr => curr.filter(n => !newNotifs.includes(n)));
-        }, 4000);
-        try { if (pixiRef.current && clickZoneRef.current) {
-          const clickRect = clickZoneRef.current.getBoundingClientRect();
-          const cx = clickRect.left + clickRect.width * 0.5;
-          const cy = clickRect.top + clickRect.height * 0.5;
-          pixiRef.current.spawnExplosion(cx, cy);
-        } } catch (e) { }
-      }
+      processAchievements(nextState, true);
 
       return nextState;
     });
@@ -469,19 +478,7 @@ export function useGameController() {
           stats: newStats
         };
 
-        const unlocked = checkAchievements(nextState);
-        if (unlocked.length > 0) {
-          applyAchievementRewards(nextState, unlocked);
-          nextState.achievements = [...(nextState.achievements || []), ...unlocked];
-          const newNotifs = unlocked.map(id => {
-            const def = ACHIEVEMENT_DEFS.find(d => d.id === id);
-            return { id, name: def?.name || "Unknown" };
-          });
-          setAchievementNotifs(curr => [...curr, ...newNotifs]);
-          setTimeout(() => {
-            setAchievementNotifs(curr => curr.filter(n => !newNotifs.includes(n)));
-          }, 4000);
-        }
+        processAchievements(nextState, false);
 
         saveState(nextState);
         return nextState;

--- a/src/logic.ts
+++ b/src/logic.ts
@@ -61,7 +61,7 @@ export function getSkillCooldownMultiplier(game: Pick<GameSnapshot, "artifacts" 
     return 1 / (1 + resonanceLevel * 0.1);
 }
 
-export function costOf(def: UpgradeDef, level: number) { return Math.floor(def.baseCost * Math.pow(def.costMult, level)); }
+export function costOf(def: { baseCost: number, costMult: number }, level: number) { return Math.floor(def.baseCost * Math.pow(def.costMult, level)); }
 
 export function isUpgradeAtMaxLevel(def: UpgradeDef, level: number): boolean {
     return typeof def.maxLevel === 'number' && level >= def.maxLevel;
@@ -71,7 +71,6 @@ export function canPurchaseUpgrade(def: UpgradeDef, level: number): boolean {
     return !isUpgradeAtMaxLevel(def, level);
 }
 
-export function artifactCost(def: ArtifactDef, level: number) { return Math.floor(def.baseCost * Math.pow(def.costMult, level)); }
 
 export function createEmptyUpgrades(): Record<string, UpgradeState> {
     return Object.fromEntries(UPGRADE_DEFS.map((u) => [u.id, { id: u.id, level: 0 }]));


### PR DESCRIPTION
Refactored duplicate logic across the codebase to improve maintainability. Replaced `artifactCost` with a generalized `costOf` and centralized achievement logic in `useGameController`.

---
*PR created automatically by Jules for task [9907717971183534674](https://jules.google.com/task/9907717971183534674) started by @deadronos*